### PR TITLE
Name/label -> name/attribute and unmapped properties distinction

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -7,7 +7,10 @@ use JsonSerializable;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Signifly\Travy\Schema\Width;
+use Signifly\Travy\Support\UnmappedProp;
+use Signifly\Travy\Support\PropsResolver;
 use Signifly\Travy\Schema\Concerns\HasProps;
+use Signifly\Travy\Support\AttributeResolver;
 use Signifly\Travy\Schema\Concerns\HasMetaData;
 
 abstract class Field extends FieldElement implements JsonSerializable
@@ -495,7 +498,7 @@ abstract class Field extends FieldElement implements JsonSerializable
     {
         $data = [
             'id' => $this->component,
-            'props' => $this->props(),
+            'props' => (new PropsResolver())->resolve($this->props()),
         ];
 
         return $data;
@@ -517,8 +520,8 @@ abstract class Field extends FieldElement implements JsonSerializable
         }
 
         return array_merge([
-            'name' => $this->attribute,
-            'label' => $this->localize($this->name),
+            'name' => $this->localize($this->name),
+            'attribute' => (new AttributeResolver())->resolve($this->attribute, $this->name),
             'fieldType' => $this->fieldType(),
         ], $this->meta());
     }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -7,7 +7,6 @@ use JsonSerializable;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Signifly\Travy\Schema\Width;
-use Signifly\Travy\Support\UnmappedProp;
 use Signifly\Travy\Support\PropsResolver;
 use Signifly\Travy\Schema\Concerns\HasProps;
 use Signifly\Travy\Support\AttributeResolver;

--- a/src/Support/AttributeResolver.php
+++ b/src/Support/AttributeResolver.php
@@ -17,7 +17,6 @@ class AttributeResolver
      *  - the value passed is falsey
      *  - an UnmappedProp is passed, but no attribute field value has been set
      * 
-     * 
      * @param  [type] $value    [description]
      * @param  string $fallback [description]
      * @return [type]           [description]

--- a/src/Support/AttributeResolver.php
+++ b/src/Support/AttributeResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Signifly\Travy\Support;
+
+use Illuminate\Support\Str;
+
+class AttributeResolver
+{
+    /**
+     * It resolves the value that should be passed for the front-end's attribute field.
+     *
+     * If an UnmappedProp object *is* passed, then its attribute field value will be used.
+     *
+     * If an UnmappedProp object is *not* passed, then the value passed in will be used.
+     *
+     * The fallback value will be used under the following conditions:
+     *  - the value passed is falsey
+     *  - an UnmappedProp is passed, but no attribute field value has been set
+     * 
+     * 
+     * @param  [type] $value    [description]
+     * @param  string $fallback [description]
+     * @return [type]           [description]
+     */
+    public function resolve($value, string $fallback): string
+    {
+        if ($value instanceof UnmappedProp) {
+            $value = $value->getAttribute();
+        }
+
+        if (! $value) {
+            /** @todo Shouldn't the manipulation of the fallback should take place *before* being passed in...? */
+            $value = str_replace(' ', '_', Str::lower($fallback));
+        }
+
+        return $value;
+    }
+}

--- a/src/Support/AttributeResolver.php
+++ b/src/Support/AttributeResolver.php
@@ -16,7 +16,6 @@ class AttributeResolver
      * The fallback value will be used under the following conditions:
      *  - the value passed is falsey
      *  - an UnmappedProp is passed, but no attribute field value has been set
-     * 
      * @param  [type] $value    [description]
      * @param  string $fallback [description]
      * @return [type]           [description]

--- a/src/Support/PropsResolver.php
+++ b/src/Support/PropsResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Signifly\Travy\Support;
+
+class PropsResolver
+{
+    public function resolve(array $props): array
+    {
+        return collect($props)->mapWithKeys(function ($value, $key) {
+            if (is_array($value)) {
+                $value = (new self())->resolve($value);
+            } elseif ($value instanceof UnmappedProp) {
+                $key = "_{$key}";
+                $value = $value->getValue();
+            }
+
+            return [$key => $value];
+        })->all();
+    }
+}

--- a/src/Support/UnmappedProp.php
+++ b/src/Support/UnmappedProp.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Signifly\Travy\Support;
+
+class UnmappedProp
+{
+    public $attribute;
+    public $value;
+
+    public function __construct($value, $attribute = null)
+    {
+        $this->value = $value;
+        $this->attribute = $attribute;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getAttribute()
+    {
+        return $this->attribute;
+    }
+
+    public function setAttribute($attribute)
+    {
+        $this->attribute = $attribute;
+
+        return $this;
+    }
+}

--- a/tests/Unit/Fields/DateTest.php
+++ b/tests/Unit/Fields/DateTest.php
@@ -4,6 +4,7 @@ namespace Signifly\Travy\Test\Unit\Fields;
 
 use Signifly\Travy\Fields\Date;
 use Signifly\Travy\Test\TestCase;
+use Signifly\Travy\Support\UnmappedProp;
 
 class DateTest extends TestCase
 {
@@ -13,12 +14,31 @@ class DateTest extends TestCase
         $date = Date::make('Created at');
 
         $expected = [
-            'name' => 'created_at',
-            'label' => 'Created at',
+            'name' => 'Created at',
+            'attribute' => 'created_at',
             'fieldType' => [
                 'id' => 'date',
                 'props' => [
                     'timestamp' => 'created_at',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $date->jsonSerialize());
+    }
+
+    /** @test */
+    public function it_serializes_unmapped_timestamp_to_json()
+    {
+        $time = time();
+        $date = Date::make('Created at', new UnmappedProp($time));
+
+        $expected = [
+            'name' => 'Created at',
+            'attribute' => 'created_at',
+            'fieldType' => [
+                'id' => 'date',
+                'props' => [
+                    '_timestamp' => $time,
                 ],
             ],
         ];

--- a/tests/Unit/Fields/ImageTest.php
+++ b/tests/Unit/Fields/ImageTest.php
@@ -14,8 +14,8 @@ class ImageTest extends TestCase
             ->size('100%', '300px');
 
         $expected = [
-            'name' => 'src',
-            'label' => 'Image',
+            'name' => 'Image',
+            'attribute' => 'src',
             'fieldType' => [
                 'id' => 'image',
                 'props' => [
@@ -36,8 +36,8 @@ class ImageTest extends TestCase
             ->fit('contain');
 
         $expected = [
-            'name' => 'src',
-            'label' => 'Image',
+            'name' => 'Image',
+            'attribute' => 'src',
             'fieldType' => [
                 'id' => 'image',
                 'props' => [

--- a/tests/Unit/Fields/Input/CheckboxTest.php
+++ b/tests/Unit/Fields/Input/CheckboxTest.php
@@ -13,8 +13,8 @@ class CheckboxTest extends TestCase
         $field = Checkbox::make('Accept Terms');
 
         $expected = [
-            'name' => 'accept_terms',
-            'label' => 'Accept Terms',
+            'name' => 'Accept Terms',
+            'attribute' => 'accept_terms',
             'fieldType' => [
                 'id' => 'input-checkbox',
                 'props' => [

--- a/tests/Unit/Fields/Input/ColorPickerTest.php
+++ b/tests/Unit/Fields/Input/ColorPickerTest.php
@@ -13,8 +13,8 @@ class ColorPickerTest extends TestCase
         $field = ColorPicker::make('Color Code');
 
         $expected = [
-            'name' => 'color_code',
-            'label' => 'Color Code',
+            'name' => 'Color Code',
+            'attribute' => 'color_code',
             'fieldType' => [
                 'id' => 'input-color-picker',
                 'props' => [

--- a/tests/Unit/Fields/Input/ImageTest.php
+++ b/tests/Unit/Fields/Input/ImageTest.php
@@ -16,8 +16,8 @@ class ImageTest extends TestCase
             ->size('80px', '80px');
 
         $expected = [
-            'name' => 'image_upload',
-            'label' => 'Image',
+            'name' => 'Image',
+            'attribute' => 'image_upload',
             'fieldType' => [
                 'id' => 'input-image',
                 'props' => [

--- a/tests/Unit/Fields/Input/ReorderItemsTest.php
+++ b/tests/Unit/Fields/Input/ReorderItemsTest.php
@@ -22,8 +22,8 @@ class ReorderItemsTest extends TestCase
             });
 
         $expected = [
-            'name' => 'variants',
-            'label' => 'Variants',
+            'name' => 'Variants',
+            'attribute' => 'variants',
             'fieldType' => [
                 'id' => 'input-reorder-items',
                 'props' => [

--- a/tests/Unit/Fields/Input/ReorderMiniTest.php
+++ b/tests/Unit/Fields/Input/ReorderMiniTest.php
@@ -20,8 +20,8 @@ class ReorderMiniTest extends TestCase
             ->value('id');
 
         $expected = [
-            'name' => 'ids',
-            'label' => 'Variants',
+            'name' => 'Variants',
+            'attribute' => 'ids',
             'fieldType' => [
                 'id' => 'input-reorder-mini',
                 'props' => [

--- a/tests/Unit/Fields/Input/ToggleTest.php
+++ b/tests/Unit/Fields/Input/ToggleTest.php
@@ -13,8 +13,8 @@ class ToggleTest extends TestCase
         $field = Toggle::make('Accept Terms');
 
         $expected = [
-            'name' => 'accept_terms',
-            'label' => 'Accept Terms',
+            'name' => 'Accept Terms',
+            'attribute' => 'accept_terms',
             'fieldType' => [
                 'id' => 'input-switch',
                 'props' => [

--- a/tests/Unit/Fields/KeyValueBoxTest.php
+++ b/tests/Unit/Fields/KeyValueBoxTest.php
@@ -15,8 +15,8 @@ class KeyValueBoxTest extends TestCase
             ->addItem('Items', 'items_count');
 
         $expected = [
-            'name' => 'some_title',
-            'label' => 'Some title',
+            'name' => 'Some title',
+            'attribute' => 'some_title',
             'fieldType' => [
                 'id' => 'key-value-box',
                 'props' => [

--- a/tests/Unit/Fields/ProgressTest.php
+++ b/tests/Unit/Fields/ProgressTest.php
@@ -14,8 +14,8 @@ class ProgressTest extends TestCase
             ->color('danger');
 
         $expected = [
-            'name' => 'status',
-            'label' => 'Status',
+            'name' => 'Status',
+            'attribute' => 'status',
             'fieldType' => [
                 'id' => 'progress',
                 'props' => [

--- a/tests/Unit/Fields/SidebarTest.php
+++ b/tests/Unit/Fields/SidebarTest.php
@@ -21,8 +21,8 @@ class SidebarTest extends TestCase
             'title' => 'History',
             'fields' => [
                 [
-                    'name' => 'created_at',
-                    'label' => 'Created at',
+                    'name' => 'Created at',
+                    'attribute' => 'created_at',
                     'fieldType' => [
                         'id' => 'date',
                         'props' => [

--- a/tests/Unit/Fields/TabTest.php
+++ b/tests/Unit/Fields/TabTest.php
@@ -24,8 +24,8 @@ class TabTest extends TestCase
             'title' => ['text' => 'Details', 'url' => ''],
             'fields' => [
                 [
-                    'name' => 'created_at',
-                    'label' => 'Created at',
+                    'name' => 'Created at',
+                    'attribute' => 'created_at',
                     'fieldType' => [
                         'id' => 'date',
                         'props' => [

--- a/tests/Unit/Fields/TextTest.php
+++ b/tests/Unit/Fields/TextTest.php
@@ -13,8 +13,8 @@ class TextTest extends TestCase
         $field = Text::make('Name');
 
         $expected = [
-            'name' => 'name',
-            'label' => 'Name',
+            'name' => 'Name',
+            'attribute' => 'name',
             'fieldType' => [
                 'id' => 'text',
                 'props' => [
@@ -31,8 +31,8 @@ class TextTest extends TestCase
         $field = Text::make('Name')->asInput();
 
         $expected = [
-            'name' => 'name',
-            'label' => 'Name',
+            'name' => 'Name',
+            'attribute' => 'name',
             'fieldType' => [
                 'id' => 'input-text',
                 'props' => [
@@ -51,8 +51,8 @@ class TextTest extends TestCase
             ->type('email');
 
         $expected = [
-            'name' => 'email',
-            'label' => 'Email',
+            'name' => 'Email',
+            'attribute' => 'email',
             'fieldType' => [
                 'id' => 'input-text',
                 'props' => [
@@ -72,8 +72,8 @@ class TextTest extends TestCase
             ->unit('cm');
 
         $expected = [
-            'name' => 'height',
-            'label' => 'Height',
+            'name' => 'Height',
+            'attribute' => 'height',
             'fieldType' => [
                 'id' => 'input-text',
                 'props' => [

--- a/tests/Unit/Fields/TimeSinceTest.php
+++ b/tests/Unit/Fields/TimeSinceTest.php
@@ -13,8 +13,8 @@ class TimeSinceTest extends TestCase
         $date = TimeSince::make('Created at');
 
         $expected = [
-            'name' => 'created_at',
-            'label' => 'Created at',
+            'name' => 'Created at',
+            'attribute' => 'created_at',
             'fieldType' => [
                 'id' => 'time-since',
                 'props' => [

--- a/tests/Unit/Support/AttributeResolverTest.php
+++ b/tests/Unit/Support/AttributeResolverTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Signifly\Travy\Test\Unit\Support;
+
+use Signifly\Travy\Test\TestCase;
+use Signifly\Travy\Support\UnmappedProp;
+use Signifly\Travy\Support\AttributeResolver;
+
+class AttributeResolverTest extends TestCase
+{
+    protected $resolver;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resolver = new AttributeResolver();
+    }
+
+    /** @test */
+    public function it_resolves_a_string()
+    {
+        $attribute = 'some_attribute';
+        $fallback = 'fallback';
+
+        $this->assertSame($attribute, ($this->resolver->resolve($attribute, $fallback)));
+    }
+
+    /** @test */
+    public function it_resolves_an_unmapped_prop_without_a_specified_attribute_value()
+    {
+        $attribute = new UnmappedProp('some_value');
+        $fallback = 'fallback';
+
+        $this->assertSame($fallback, ($this->resolver->resolve($attribute, $fallback)));
+    }
+
+    /** @test */
+    public function it_resolves_an_unmapped_prop_with_a_specified_attribute_value()
+    {
+        $specifiedAttributeValue = 'specified_attribute_value';
+        $attribute = new UnmappedProp('some_value', $specifiedAttributeValue);
+        $fallback = 'fallback';
+
+        $this->assertSame($specifiedAttributeValue, ($this->resolver->resolve($attribute, $fallback)));
+    }
+}

--- a/tests/Unit/Support/PropsResolverTest.php
+++ b/tests/Unit/Support/PropsResolverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Signifly\Travy\Test\Unit\Support;
+
+use Signifly\Travy\Test\TestCase;
+use Signifly\Travy\Support\UnmappedProp;
+use Signifly\Travy\Support\PropsResolver;
+
+class PropsResolverTest extends TestCase
+{
+    protected $resolver;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resolver = new PropsResolver();
+    }
+
+    /** @test */
+    public function it_resolves_mapped_props()
+    {
+        $props = [
+            'this' => 'that',
+            'list' => [
+                ['key_a' => 'value_aa', 'key_b' => 'value_ba'],
+                ['key_a' => 'value_ab', 'key_b' => 'value_bb'],
+                ['key_a' => 'value_ac', 'key_b' => 'value_bc'],
+            ],
+        ];
+
+        $expected = $props;
+
+        $this->assertSame($expected, $this->resolver->resolve($props));
+    }
+
+    /** @test */
+    public function it_resolves_unmapped_props()
+    {
+        $props = [
+            'this' => new UnmappedProp('that'),
+            'list' => [
+                ['key_a' => 'value_aa', 'key_b' => 'value_ba'],
+                ['key_a' => 'value_ab', 'key_b' => new UnmappedProp('value_bb')],
+                ['key_a' => 'value_ac', 'key_b' => 'value_bc'],
+            ],
+        ];
+
+        $expected = [
+            '_this' => 'that',
+            'list' => [
+                ['key_a' => 'value_aa', 'key_b' => 'value_ba'],
+                ['key_a' => 'value_ab', '_key_b' => 'value_bb'],
+                ['key_a' => 'value_ac', 'key_b' => 'value_bc'],
+            ],
+        ];
+
+        $this->assertSame($expected, $this->resolver->resolve($props));
+    }
+}


### PR DESCRIPTION
A field's name/label values have been switched and label's been renamed to attribute.

Unmapped properties are now distinguished by having an underscore prepended to the property key.  A field's attribute gets special handling if passed in as an unmapped property.

Existing tests updated, new tests introduced.